### PR TITLE
v1.1.06 - Add a Manage Login Codes page

### DIFF
--- a/Meet The Teacher/CHANGEDB.php
+++ b/Meet The Teacher/CHANGEDB.php
@@ -72,3 +72,11 @@ $sql[$count][1] = "";
 ++$count;
 $sql[$count][0] = '1.1.05';
 $sql[$count][1] = "";
+
+//v1.1.06
+++$count;
+$sql[$count][0] = '1.1.06';
+$sql[$count][1] = "
+INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, `description`, `URLList`, `entryURL`, `defaultPermissionAdmin`, `defaultPermissionTeacher`, `defaultPermissionStudent`, `defaultPermissionParent`, `defaultPermissionSupport`, `categoryPermissionStaff`, `categoryPermissionStudent`, `categoryPermissionParent`, `categoryPermissionOther`) VALUES ((SELECT gibbonModuleID FROM gibbonModule WHERE name='Meet The Teacher'), 'Manage Login Codes', 0, 'Admin', 'Allows a user to manage Meet The Teacher parent login codes.', 'loginCodes_manage.php,loginCodes_manage_add.php,loginCodes_manage_edit.php,loginCodes_manage_delete.php', 'loginCodes_manage.php', 'Y', 'N', 'N', 'N', 'N', 'Y', 'N', 'N', 'N');end
+INSERT INTO `gibbonPermission` (`gibbonRoleID` ,`gibbonActionID`) VALUES ('001', (SELECT gibbonActionID FROM gibbonAction JOIN gibbonModule ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) WHERE gibbonModule.name='Meet The Teacher' AND gibbonAction.name='Manage Login Codes'));end
+";

--- a/Meet The Teacher/CHANGELOG.txt
+++ b/Meet The Teacher/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+1.1.06
+------
+Added the ability to manage parent login codes
+
 1.1.05
 ------
 Refactored Breadcrumbs for version >= v17

--- a/Meet The Teacher/loginCodes_manage.php
+++ b/Meet The Teacher/loginCodes_manage.php
@@ -1,0 +1,99 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Tables\DataTable;
+use Gibbon\Services\Format;
+use Gibbon\Module\MeetTheTeacher\Domain\LoginCodeGateway;
+use Gibbon\Forms\Form;
+
+if (isActionAccessible($guid, $connection2, '/modules/Meet The Teacher/loginCodes_manage.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    // Proceed!
+    $page->breadcrumbs->add(__m('Manage Login Codes'));
+
+    if (isset($_GET['return'])) {
+        returnProcess($guid, $_GET['return'], null, null);
+    }
+
+    $search = $_GET['search'] ?? '';
+    $loginCodeGateway = $container->get(LoginCodeGateway::class);
+
+    // QUERY
+    $criteria = $loginCodeGateway->newQueryCriteria()
+        ->searchBy($loginCodeGateway->getSearchableColumns(), $search)
+        ->sortBy(['surname', 'preferredName'])
+        ->fromPOST();
+
+    $form = Form::create('filter', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form->setTitle(__('Search'));
+    $form->setClass('noIntBorder fullWidth');
+
+    $form->addHiddenValue('q', '/modules/Meet The Teacher/loginCodes_manage.php');
+
+    $row = $form->addRow();
+        $row->addLabel('search', __('Search For'))->description(__('Preferred, surname, username'));
+        $row->addTextField('search')->setValue($criteria->getSearchText());
+
+    $row = $form->addRow();
+        $row->addSearchSubmit($gibbon->session, __('Clear Search'));
+
+    echo $form->getOutput();
+
+
+    $loginCodes = $loginCodeGateway->queryLoginCodes($criteria);
+
+    // DATA TABLE
+    $table = DataTable::createPaginated('loginCodes', $criteria);
+    $table->setTitle(__('View'));
+    $table->setDescription(__m('This page enables you to manage Parent Login Codes, which are generated in the Meet The Teacher system, and used to connect the parent dashboard to the Meet The Teacher page via automated login.'));
+
+    $table->addHeaderAction('add', __('Add'))
+        ->addParam('search', $criteria->getSearchText())
+        ->setURL('/modules/Meet The Teacher/loginCodes_manage_add.php')
+        ->displayLabel();
+
+    $table->modifyRows(function ($loginCode, $row) {
+        if ($loginCode['status'] != 'Full') $row->addClass('error');
+        return $row;
+    });
+
+    $table->addColumn('name', __('Name'))
+        ->sortable(['surname', 'preferredName'])
+        ->format(function ($person) {
+            return Format::name($person['title'], $person['preferredName'], $person['surname'], 'Staff', true, true);
+        });
+    $table->addColumn('loginCode', __m('Login Code'));
+
+
+    // ACTIONS
+    $table->addActionColumn()
+        ->addParam('search', $criteria->getSearchText())
+        ->addParam('meetTheTeacherLoginID')
+        ->format(function ($loginCode, $actions) {
+            $actions->addAction('edit', __('Edit'))
+                    ->setURL('/modules/Meet The Teacher/loginCodes_manage_edit.php');
+
+            $actions->addAction('delete', __('Delete'))
+                    ->setURL('/modules/Meet The Teacher/loginCodes_manage_delete.php');
+        });
+
+    echo $table->render($loginCodes);
+}

--- a/Meet The Teacher/loginCodes_manage_add.php
+++ b/Meet The Teacher/loginCodes_manage_add.php
@@ -1,0 +1,66 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
+
+if (isActionAccessible($guid, $connection2, '/modules/Meet The Teacher/loginCodes_manage_add.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    // Proceed!
+    $search = $_GET['search'] ?? '';
+
+    $page->breadcrumbs
+        ->add(__m('Manage Login Codes'), 'loginCodes_manage.php', ['search' => $search])
+        ->add(__m('Add Login Code'));
+
+    $editLink = '';
+    if (isset($_GET['editID'])) {
+        $editLink = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Meet The Teacher/loginCodes_manage_edit.php&meetTheTeacherLoginID='.$_GET['editID'].'&search='.$search;
+    }
+    if (isset($_GET['return'])) {
+        returnProcess($guid, $_GET['return'], $editLink, null);
+    }
+
+    if ($search != '') {
+        echo "<div class='linkTop'>";
+        echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Meet The Teacher/loginCodes_manage.php&search=$search'>".__('Back to Search Results').'</a>';
+        echo '</div>';
+    }
+
+    $form = Form::create('loginCodesManage', $gibbon->session->get('absoluteURL').'/modules/Meet The Teacher/loginCodes_manage_addProcess.php?search='.$search);
+    $form->setFactory(DatabaseFormFactory::create($pdo));
+
+    $form->addHiddenValue('address', $gibbon->session->get('address'));
+
+    $row = $form->addRow();
+        $row->addLabel('gibbonPersonID', __('Parent'));
+        $row->addSelectUsers('gibbonPersonID');
+
+    $row = $form->addRow();
+        $row->addLabel('loginCode', __m('Parent Login Code'))->description(__('Generated in the Meet The Teacher system.'));
+        $row->addTextField('loginCode')->maxLength(120)->required();
+
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
+
+    echo $form->getOutput();
+}

--- a/Meet The Teacher/loginCodes_manage_addProcess.php
+++ b/Meet The Teacher/loginCodes_manage_addProcess.php
@@ -1,0 +1,63 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Module\MeetTheTeacher\Domain\LoginCodeGateway;
+
+require_once '../../gibbon.php';
+
+$search = $_GET['search'] ?? '';
+
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Meet The Teacher/loginCodes_manage_add.php&search='.$search;
+
+if (isActionAccessible($guid, $connection2, '/modules/Meet The Teacher/loginCodes_manage_add.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+    exit;
+} else {
+    // Proceed!
+    $loginCodeGateway = $container->get(LoginCodeGateway::class);
+
+    $data = [
+        'gibbonPersonID' => $_POST['gibbonPersonID'] ?? '',
+        'loginCode'      => $_POST['loginCode'] ?? '',
+    ];
+
+    // Validate the required values are present
+    if (empty($data['gibbonPersonID']) || empty($data['loginCode'])) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Validate that this record is unique
+    if (!$loginCodeGateway->unique($data, ['gibbonPersonID', 'loginCode'])) {
+        $URL .= '&return=error7';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Create the record
+    $meetTheTeacherLoginID = $loginCodeGateway->insert($data);
+
+    $URL .= !$meetTheTeacherLoginID
+        ? "&return=error2"
+        : "&return=success0";
+
+    header("Location: {$URL}&editID=$meetTheTeacherLoginID");
+}

--- a/Meet The Teacher/loginCodes_manage_delete.php
+++ b/Meet The Teacher/loginCodes_manage_delete.php
@@ -1,0 +1,44 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Module\MeetTheTeacher\Domain\LoginCodeGateway;
+
+if (isActionAccessible($guid, $connection2, '/modules/Meet The Teacher/loginCodes_manage_delete.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    // Proceed!
+    $meetTheTeacherLoginID = $_GET['meetTheTeacherLoginID'] ?? '';
+    
+    if (empty($meetTheTeacherLoginID)) {
+        $page->addError(__('You have not specified one or more required parameters.'));
+        return;
+    }
+
+    $values = $container->get(LoginCodeGateway::class)->getByID($meetTheTeacherLoginID);
+
+    if (empty($values)) {
+        $page->addError(__('The specified record cannot be found.'));
+        return;
+    }
+
+    $form = DeleteForm::createForm($gibbon->session->get('absoluteURL').'/modules/Meet The Teacher/loginCodes_manage_deleteProcess.php?meetTheTeacherLoginID='.$meetTheTeacherLoginID);
+    echo $form->getOutput();
+}

--- a/Meet The Teacher/loginCodes_manage_deleteProcess.php
+++ b/Meet The Teacher/loginCodes_manage_deleteProcess.php
@@ -1,0 +1,54 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Module\MeetTheTeacher\Domain\LoginCodeGateway;
+
+require_once '../../gibbon.php';
+
+$meetTheTeacherLoginID = $_GET['meetTheTeacherLoginID'] ?? '';
+
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Meet The Teacher/loginCodes_manage.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Meet The Teacher/loginCodes_manage_delete.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+    exit;
+} elseif (empty($meetTheTeacherLoginID)) {
+    $URL .= '&return=error1';
+    header("Location: {$URL}");
+    exit;
+} else {
+    // Proceed!
+    $loginCodeGateway = $container->get(LoginCodeGateway::class);
+
+    $values = $loginCodeGateway->getByID($meetTheTeacherLoginID);
+    if (empty($values)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $deleted = $loginCodeGateway->delete($meetTheTeacherLoginID);
+
+    $URL .= !$deleted
+        ? '&return=error2'
+        : '&return=success0';
+
+    header("Location: {$URL}");
+}

--- a/Meet The Teacher/loginCodes_manage_edit.php
+++ b/Meet The Teacher/loginCodes_manage_edit.php
@@ -1,0 +1,81 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\Form;
+use Gibbon\Services\Format;
+use Gibbon\Module\MeetTheTeacher\Domain\LoginCodeGateway;
+use Gibbon\Forms\DatabaseFormFactory;
+
+if (isActionAccessible($guid, $connection2, '/modules/Meet The Teacher/loginCodes_manage_edit.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    //Proceed!
+    $search = $_GET['search'] ?? '';
+
+    $page->breadcrumbs
+        ->add(__m('Manage Login Codes'), 'loginCodes_manage.php', ['search' => $search])
+        ->add(__m('Edit Login Code'));
+
+    if (isset($_GET['return'])) {
+        returnProcess($guid, $_GET['return'], null, null);
+    }
+
+    if ($search != '') {
+        echo "<div class='linkTop'>";
+        echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Meet The Teacher/loginCodes_manage.php&search=$search'>".__('Back to Search Results').'</a>';
+        echo '</div>';
+    }
+
+    $meetTheTeacherLoginID = $_GET['meetTheTeacherLoginID'] ?? '';
+    $loginCodeGateway = $container->get(LoginCodeGateway::class);
+
+    if (empty($meetTheTeacherLoginID)) {
+        $page->addError(__('You have not specified one or more required parameters.'));
+        return;
+    }
+
+    $values = $loginCodeGateway->getByID($meetTheTeacherLoginID);
+    if (empty($values)) {
+        $page->addError(__('The specified record cannot be found.'));
+        return;
+    }
+
+    $form = Form::create('loginCodesManage', $gibbon->session->get('absoluteURL').'/modules/Meet The Teacher/loginCodes_manage_editProcess.php?search='.$search);
+    $form->setFactory(DatabaseFormFactory::create($pdo));
+
+    $form->addHiddenValue('address', $gibbon->session->get('address'));
+    $form->addHiddenValue('meetTheTeacherLoginID', $meetTheTeacherLoginID);
+
+    $row = $form->addRow();
+        $row->addLabel('personLabel', __('Parent'));
+        $row->addSelectUsers('person')->readonly()->selected($values['gibbonPersonID']);
+
+    $row = $form->addRow();
+        $row->addLabel('loginCode', __m('Parent Login Code'))->description(__('Generated in the Meet The Teacher system.'));
+        $row->addTextField('loginCode')->maxLength(120)->required();
+
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
+
+    $form->loadAllValuesFrom($values);
+
+    echo $form->getOutput();
+}

--- a/Meet The Teacher/loginCodes_manage_editProcess.php
+++ b/Meet The Teacher/loginCodes_manage_editProcess.php
@@ -1,0 +1,63 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Module\MeetTheTeacher\Domain\LoginCodeGateway;
+
+require_once '../../gibbon.php';
+
+$search = $_GET['search'] ?? '';
+$meetTheTeacherLoginID = $_POST['meetTheTeacherLoginID'] ?? '';
+
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Meet The Teacher/loginCodes_manage_edit.php&meetTheTeacherLoginID='.$meetTheTeacherLoginID.'&search='.$search;
+
+if (isActionAccessible($guid, $connection2, '/modules/Meet The Teacher/loginCodes_manage_edit.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+    exit;
+} else {
+    // Proceed!
+    $loginCodeGateway = $container->get(LoginCodeGateway::class);
+
+    $data = [
+        'loginCode' => $_POST['loginCode'] ?? '',
+    ];
+
+    // Validate the required values are present
+    if (empty($meetTheTeacherLoginID) || empty($data['loginCode'])) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Validate the database relationships exist
+    if (!$loginCodeGateway->exists($meetTheTeacherLoginID)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Update the record
+    $updated = $loginCodeGateway->update($meetTheTeacherLoginID, $data);
+
+    $URL .= !$updated
+        ? "&return=error2"
+        : "&return=success0";
+
+    header("Location: {$URL}");
+}

--- a/Meet The Teacher/manifest.php
+++ b/Meet The Teacher/manifest.php
@@ -25,7 +25,7 @@ $description = 'Provides an API for data syncing, and and interface for acess, t
 $entryURL = 'meetTheTeacher_view.php';
 $type = 'Additional';
 $category = 'Other';
-$version = '1.1.05';
+$version = '1.1.06';
 $author = 'Jim Speirs, Sandra Kuipers & Ross Parker';
 $url = 'http://gibbonedu.org';
 
@@ -66,6 +66,22 @@ $actionRows[1]['categoryPermissionStaff'] = 'Y';
 $actionRows[1]['categoryPermissionStudent'] = 'N';
 $actionRows[1]['categoryPermissionParent'] = 'N';
 $actionRows[1]['categoryPermissionOther'] = 'N';
+
+$actionRows[2]['name'] = 'Manage Login Codes';
+$actionRows[2]['precedence'] = '0';
+$actionRows[2]['category'] = 'Admin';
+$actionRows[2]['description'] = 'Allows a user to manage Meet The Teacher parent login codes.';
+$actionRows[2]['URLList'] = 'loginCodes_manage.php,loginCodes_manage_add.php,loginCodes_manage_edit.php,loginCodes_manage_delete.php';
+$actionRows[2]['entryURL'] = 'loginCodes_manage.php';
+$actionRows[2]['defaultPermissionAdmin'] = 'Y';
+$actionRows[2]['defaultPermissionTeacher'] = 'N';
+$actionRows[2]['defaultPermissionStudent'] = 'N';
+$actionRows[2]['defaultPermissionParent'] = 'N';
+$actionRows[2]['defaultPermissionSupport'] = 'N';
+$actionRows[2]['categoryPermissionStaff'] = 'Y';
+$actionRows[2]['categoryPermissionStudent'] = 'N';
+$actionRows[2]['categoryPermissionParent'] = 'N';
+$actionRows[2]['categoryPermissionOther'] = 'N';
 
 //Settings
 $gibbonSetting[0] = "INSERT INTO `gibbonSetting` (`gibbonSettingID` ,`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES (NULL , 'Meet The Teacher', 'yearGroups', 'Year Groups', 'List of year group short names to match against, as a comma-separated list.', 'Y07,Y08,Y09,Y10,Y11,Y12,Y13');";

--- a/Meet The Teacher/src/Domain/LoginCodeGateway.php
+++ b/Meet The Teacher/src/Domain/LoginCodeGateway.php
@@ -1,0 +1,48 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\MeetTheTeacher\Domain;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+class LoginCodeGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'meetTheTeacherLogin';
+    private static $primaryKey = 'meetTheTeacherLoginID';
+    private static $searchableColumns = ['gibbonPerson.preferredName', 'gibbonPerson.surname', 'gibbonPerson.username'];
+    
+    /**
+     * @param QueryCriteria $criteria
+     * @return DataSet
+     */
+    public function queryLoginCodes(QueryCriteria $criteria)
+    {
+        $query = $this
+            ->newQuery()
+            ->from($this->getTableName())
+            ->cols(['meetTheTeacherLogin.meetTheTeacherLoginID', 'gibbonPerson.title', 'gibbonPerson.preferredName', 'gibbonPerson.username', 'gibbonPerson.surname', 'gibbonPerson.status', 'meetTheTeacherLogin.loginCode'])
+            ->innerJoin('gibbonPerson', 'gibbonPerson.gibbonPersonID=meetTheTeacherLogin.gibbonPersonID');
+
+        return $this->runQuery($query, $criteria);
+    }
+}

--- a/Meet The Teacher/version.php
+++ b/Meet The Teacher/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '1.1.05';
+$moduleVersion = '1.1.06';


### PR DESCRIPTION
Adds a Manage Login Codes page for adding/editing/deleting Parent Login Codes, which are generated in the Meet The Teacher system. These codes are used to connect the parent dashboard to the Meet The Teacher page via automated login.

<img width="816" alt="Screen Shot 2019-10-01 at 11 40 28 AM" src="https://user-images.githubusercontent.com/897700/65932441-4baa4280-e440-11e9-979e-f4d8c7c380ff.png">
